### PR TITLE
Fix autoupdate asset

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,7 @@ ram.runtime = "50M"
         url = "https://github.com/mattermost/focalboard/releases/download/v7.11.3/focalboard-server-linux-amd64.tar.gz"
         sha256 = "3515ef5b90fe2d958b8869e0191915f0ca46ee4e6950e16c9647423981ebeecd"
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset = "^.*focalboard-*linux-amd64.tar.gz$"
+        autoupdate.asset = "^.*focalboard-.*linux-amd64.tar.gz$"
 
     [resources.ports]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -44,7 +44,7 @@ ram.runtime = "50M"
         url = "https://github.com/mattermost/focalboard/releases/download/v7.11.3/focalboard-server-linux-amd64.tar.gz"
         sha256 = "3515ef5b90fe2d958b8869e0191915f0ca46ee4e6950e16c9647423981ebeecd"
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset = "^focalboard-server-linux-amd64.tar.gz$"
+        autoupdate.asset = "^.*focalboard-*linux-amd64.tar.gz$"
 
     [resources.ports]
 


### PR DESCRIPTION
Fix autoupdate asset

## Problem

Autoupdate fails. See https://paste.yunohost.org/raw/obuximumef

```
Traceback (most recent call last):
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 637, in run_autoupdate_for_multiprocessing
    result = AppAutoUpdater(app).run(edit=edit, commit=commit, pr=pr)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 233, in run
    update = self.get_source_update(source, infos)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 387, in get_source_update
    result = self.get_latest_version_and_asset(strategy, asset, autoupdate)
  File "/var/www/app_yunohost/apps/tools/autoupdate_app_sources/autoupdate_app_sources.py", line 507, in get_latest_version_and_asset
    raise RuntimeError(
RuntimeError: No assets matching regex '^focalboard-server-linux-amd64.tar.gz$' in ['mattermost-plugin-focalboard-v8.0.0-darwin-amd64.tar.gz', 'mattermost-plugin-focalboard-v8.0.0-darwin-amd64.tar.gz.asc', 'mattermost-plugin-focalboard-v8.0.0-darwin-amd64.tar.gz.sig', 'mattermost-plugin-focalboard-v8.0.0-darwin-arm64.tar.gz', 'mattermost-plugin-focalboard-v8.0.0-darwin-arm64.tar.gz.asc', 'mattermost-plugin-focalboard-v8.0.0-darwin-arm64.tar.gz.sig', 'mattermost-plugin-focalboard-v8.0.0-linux-amd64.tar.gz', 'mattermost-plugin-focalboard-v8.0.0-linux-amd64.tar.gz.asc', 'mattermost-plugin-focalboard-v8.0.0-linux-amd64.tar.gz.sig', 'mattermost-plugin-focalboard-v8.0.0-linux-arm64.tar.gz', 'mattermost-plugin-focalboard-v8.0.0-linux-arm64.tar.gz.asc', 'mattermost-plugin-focalboard-v8.0.0-linux-arm64.tar.gz.sig', 'mattermost-plugin-focalboard-v8.0.0-windows-amd64.tar.gz', 'mattermost-plugin-focalboard-v8.0.0-windows-amd64.tar.gz.asc', 'mattermost-plugin-focalboard-v8.0.0-windows-amd64.tar.gz.sig', 'mattermost-plugin-focalboard.tar.gz', 'mattermost-plugin-focalboard.tar.gz.asc', 'mattermost-plugin-focalboard.tar.gz.sig'].
Full release details on https://github.com/mattermost/focalboard/releases/tag/v8.0.0.
```

## Solution

This happens as the release assets have been renamed from version 8.0.0 on. See https://github.com/mattermost/focalboard/releases 
To solve it I adopted the regex from `^focalboard-server-linux-amd64.tar.gz$` to `^.*focalboard-*linux-amd64.tar.gz$`.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
